### PR TITLE
Feature. Highlight search term in result.

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,17 @@
+version: v1.0
+name: Initial Pipeline
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+blocks:
+  - name: 'Block #1'
+    task:
+      jobs:
+        - name: 'Job #1'
+          commands:
+            - checkout
+            - docker-compose up -d db redis search
+            - bundle install --deployment --path vendor/bundle
+            - 'bundle exec rails app:db:drop app:db:create app:db:migrate'
+            - bundle exec rails test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,9 @@ blocks:
         - name: 'Job #1'
           commands:
             - checkout
+            - cd test/dummy
             - docker-compose up -d db redis search
+            - cd ../../
             - bundle install --deployment --path vendor/bundle
             - 'bundle exec rails app:db:drop app:db:create app:db:migrate'
             - bundle exec rails test

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Kommandant.configure do |config|
   
   # We assume there is a logged in user and therefore a current_user method. The name of this method can be set here. It defaults to current_user.
   # config.current_user_method = current_account
+
+  # Kommandant highlights search terms by default. Uncomment this to turn it off. This only turns highlighting off, when using the views provided by the gem. You can still highlight terms if providing your own partial.
+  # config.highligt_search_term = false
   
   # If you use Kredis, Kommandant can display the current user's most recently used commands. It requires your user model to have kredis_unique_list called recent_commands. If you don't use Kredis or do not want this behavior, it can be disabled. It defaults to being enabled.
   # class User < ApplicationRecord

--- a/app/assets/builds/kommandant.css
+++ b/app/assets/builds/kommandant.css
@@ -271,6 +271,11 @@
   border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
 
+.kommandant-bg-amber-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(253 230 138 / var(--tw-bg-opacity));
+}
+
 .kommandant-bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));

--- a/app/views/kommandant/commands/searches/show.html.erb
+++ b/app/views/kommandant/commands/searches/show.html.erb
@@ -19,9 +19,9 @@
         <% @results.each do |result| %>
           <%# TODO: How about a default? %>
           <% if partial_exists_for_result?(result) %>
-            <%= render result.resource, result: result %>
+            <%= render result.resource, result: result, query: params[:query] %>
           <% else %>
-            <%= render "kommandant/shared/command_palette/result", result: result %>
+            <%= render "kommandant/shared/command_palette/result", result: result, query: params[:query] %>
           <% end %>
         <% end %>
       </ul>

--- a/app/views/kommandant/commands/searches/show.html.erb
+++ b/app/views/kommandant/commands/searches/show.html.erb
@@ -47,7 +47,7 @@
     <div class="kommandant-flex kommandant-justify-end kommandant-items-center kommandant-divide-x kommandant-bg-gray-50 kommandant-py-2.5 kommandant-px-4 kommandant-text-xs kommandant-text-gray-700">
       <div class="kommandant-pr-2 kommandant-flex kommandant-flex-wrap kommandant-justify-end kommandant-items-center kommandant-space-x-2">
         <span><%= t("kommandant.pagination.prev").html_safe %>:</span>
-        
+
         <div class="kommandant-flex kommandant-items-center kommandant-space-x-1">
           <kbd class="kommandant-px-1 kommandant-py-0.5 kommandant-rounded kommandant-border kommandant-border-gray-400 kommandant-bg-white kommandant-font-semibold kommandant-text-gray-900">Ctrl</kbd>
           <span>+</span>
@@ -57,7 +57,7 @@
 
       <div class="kommandant-pl-2 kommandant-flex kommandant-flex-wrap kommandant-justify-end kommandant-items-center kommandant-space-x-2">
         <span><%= t("kommandant.pagination.next").html_safe %>:</span>
-        
+
         <div class="kommandant-flex kommandant-items-center kommandant-space-x-1">
           <kbd class="kommandant-px-1 kommandant-py-0.5 kommandant-rounded kommandant-border kommandant-border-gray-400 kommandant-bg-white kommandant-font-semibold kommandant-text-gray-900">Ctrl</kbd>
           <span>+</span>

--- a/app/views/kommandant/shared/command_palette/_result.html.erb
+++ b/app/views/kommandant/shared/command_palette/_result.html.erb
@@ -1,6 +1,6 @@
 <li>
   <%= link_to result.path, data: {active: false, keyboard_navigation_target: "focusable", action: "mouseenter->keyboard-navigation#focus click->command-palette#showLoadingMessage", turbo_method: result.http_method, turbo_frame: "_top"}, class: "kommandant-group kommandant-cursor-default kommandant-select-none kommandant-flex kommandant-items-center kommandant-px-3 kommandant-py-2 kommandant-rounded-md data-[active=true]:kommandant-bg-slate-600 data-[active=true]:kommandant-text-white group-data-[active=true]:kommandant-outline-none" do %>
-    <span class="kommandant-ml-3 kommandant-flex-auto kommandant-truncate"><%= result.name %></span>
+    <span class="kommandant-ml-3 kommandant-flex-auto kommandant-truncate"><%= highlight(result.name, query) { |match| tag.b(match, class: "kommandant-bg-amber-200 kommandant-text-gray-900") } %></span>
     <span class="kommandant-ml-3 kommandant-hidden group-data-[active=true]:kommandant-inline kommandant-flex-none kommandant-text-indigo-100"><%= t("kommandant.navigation.jump_to") %></span>
   <% end %>
 </li>

--- a/app/views/kommandant/shared/command_palette/_result.html.erb
+++ b/app/views/kommandant/shared/command_palette/_result.html.erb
@@ -1,6 +1,10 @@
 <li>
   <%= link_to result.path, data: {active: false, keyboard_navigation_target: "focusable", action: "mouseenter->keyboard-navigation#focus click->command-palette#showLoadingMessage", turbo_method: result.http_method, turbo_frame: "_top"}, class: "kommandant-group kommandant-cursor-default kommandant-select-none kommandant-flex kommandant-items-center kommandant-px-3 kommandant-py-2 kommandant-rounded-md data-[active=true]:kommandant-bg-slate-600 data-[active=true]:kommandant-text-white group-data-[active=true]:kommandant-outline-none" do %>
-    <span class="kommandant-ml-3 kommandant-flex-auto kommandant-truncate"><%= highlight(result.name, query) { |match| tag.b(match, class: "kommandant-bg-amber-200 kommandant-text-gray-900") } %></span>
+    <% if Kommandant.config.highlight_search_term %>
+      <span class="kommandant-ml-3 kommandant-flex-auto kommandant-truncate"><%= highlight(result.name, query) { |match| tag.b(match, class: "kommandant-bg-amber-200 kommandant-text-gray-900") } %></span>
+    <% else %>
+      <span class="kommandant-ml-3 kommandant-flex-auto kommandant-truncate"><%= result.name %></span>
+    <% end %>
     <span class="kommandant-ml-3 kommandant-hidden group-data-[active=true]:kommandant-inline kommandant-flex-none kommandant-text-indigo-100"><%= t("kommandant.navigation.jump_to") %></span>
   <% end %>
 </li>

--- a/lib/kommandant.rb
+++ b/lib/kommandant.rb
@@ -11,6 +11,7 @@ module Kommandant
   setting :admin_only_filter_lambda
   setting :parent_controller, default: "::ApplicationController"
   setting :current_user_method, default: "current_user"
+  setting :highlight_search_term, default: true
   setting :recent_commands do
     setting :enabled, default: true
   end

--- a/test/controllers/kommandant/commands/searches_controller_test.rb
+++ b/test/controllers/kommandant/commands/searches_controller_test.rb
@@ -12,7 +12,7 @@ class Kommandant::Commands::SearchesControllerTest < ActionDispatch::Integration
 
       get kommandant.command_searches_path(:find_user), params: {query: resource.id}
 
-      assert_select "ul li a[href='#{expected_path}']", text: resource.name
+      assert_select "ul li a[href='#{expected_path}'] span", text: "Show #{resource.name}"
     end
 
     it "renders a default partial, if no partial is found" do
@@ -38,7 +38,7 @@ class Kommandant::Commands::SearchesControllerTest < ActionDispatch::Integration
 
         get kommandant.command_searches_path(:find_user), params: {query: resource.id}
 
-        assert_select "ul li a[href='#{expected_path}']", resource.name
+        assert_select "ul li a[href='#{expected_path}'] span", "Show #{resource.name}"
       end
 
       it "does not find results, user is not allowed to see" do

--- a/test/controllers/kommandant/commands/searches_controller_test.rb
+++ b/test/controllers/kommandant/commands/searches_controller_test.rb
@@ -15,6 +15,16 @@ class Kommandant::Commands::SearchesControllerTest < ActionDispatch::Integration
       assert_select "ul li a[href='#{expected_path}'] span", text: "Show #{resource.name}"
     end
 
+    it "highlights the search term in the results" do
+      resource = users(:not_admin)
+
+      get kommandant.command_searches_path(:find_user), params: {query: resource.name[0..-4]}
+
+      assert_select "ul li a" do |result|
+        assert_select result, "b.kommandant-bg-amber-200", text: resource.name[0..-4]
+      end
+    end
+
     it "renders a default partial, if no partial is found" do
       old_filter = Kommandant.config.search_result_filter_lambda
       Kommandant.config.search_result_filter_lambda = nil

--- a/test/controllers/kommandant/commands/searches_controller_test.rb
+++ b/test/controllers/kommandant/commands/searches_controller_test.rb
@@ -25,6 +25,16 @@ class Kommandant::Commands::SearchesControllerTest < ActionDispatch::Integration
       end
     end
 
+    it "does not highlight the search term in the results, if the setting is turned off" do
+      Kommandant.config.highlight_search_term = false
+      resource = users(:not_admin)
+
+      get kommandant.command_searches_path(:find_user), params: {query: resource.name[0..-4]}
+
+      assert_select "ul li a span", text: "Show #{resource.name}"
+      Kommandant.config.highlight_search_term = true
+    end
+
     it "renders a default partial, if no partial is found" do
       old_filter = Kommandant.config.search_result_filter_lambda
       Kommandant.config.search_result_filter_lambda = nil

--- a/test/controllers/kommandant/commands_controller_test.rb
+++ b/test/controllers/kommandant/commands_controller_test.rb
@@ -11,7 +11,7 @@ class CommandsControllerTest < ActionDispatch::IntegrationTest
       # that might make state handling simpler
       get kommandant.command_path(:find_user)
 
-      assert_select "a.inline-flex", text: "Find user", href: kommandant.searches_path
+      assert_select "a.kommandant-inline-flex", text: "Find user", href: kommandant.searches_path
     end
 
     it "shows a new search form" do

--- a/test/controllers/kommandant/searches_controller_test.rb
+++ b/test/controllers/kommandant/searches_controller_test.rb
@@ -18,7 +18,7 @@ class SearchesControllerTest < ActionDispatch::IntegrationTest
     it "renders an empty state, when there are no results" do
       get kommandant.searches_path, params: {query: "missing"}
 
-      assert_select "div.py-14", text: "#{I18n.t("kommandant.shared.command_palette.empty_state.text")} missing"
+      assert_select "div.kommandant-py-14", text: "#{I18n.t("kommandant.shared.command_palette.empty_state.text")} missing"
     end
 
     describe "admin only filter" do

--- a/test/dummy/app/views/kommandant/commands/users/_user.html.erb
+++ b/test/dummy/app/views/kommandant/commands/users/_user.html.erb
@@ -1,3 +1,0 @@
-<li>
-  <%= link_to result.resource.name, result.path %>
-</li>


### PR DESCRIPTION
<img width="694" alt="image" src="https://github.com/traels-it/kommandant/assets/23448075/ec31f48d-79e0-410a-9ede-6e62c2a3d352">

Search terms are highlighted in search results by default.
This can be turned off by setting the highlight_search_term configuration to false

```ruby
Kommandant.configure do |config|
  config.highlight_search_term = false
end
```