### PR TITLE
Feature. Rake tasks for reindexing and clearing the search engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,25 @@ Stimulus data-action attributes are used to trigger the command palette. There a
 </body>
 ```
 
+## Tasks
+The gem comes with several tasks for reindexing and clearing the search engine. You will probably use `rails kommandant:reindex` the most. We recommend you run this on every deploy to make sure the search engine contains the data you expect.
+
+```
+rails kommandant:clear_command_index                 # Clears the Kommandant commands from the search engine
+rails kommandant:clear_indexes                       # Clears the search engine of all commands and models
+rails kommandant:clear_model_index                   # Clears the search engine of all models set up with Kommandant
+rails kommandant:install:migrations                  # Copy migrations from kommandant to application
+rails kommandant:reindex                             # Reindexes all commands and models
+rails kommandant:reindex_commands                    # Reindexes all commmands defined in the commands json file (or w...
+rails kommandant:reindex_models                      # Reindexes all models set up with Kommandant
+```
+
 ## Future improvements
 We will continue to improve this gem. Some of the things on the planning board are:
 - Install task that generates both a default config and commands file
 - Database-backed commands
 - Support for navigation commands
 - Default paths for resource commands
-- Index commands task
 - Build own macros for indexing models in meilisearch
 - Optional command icons
 - A default icon set and partial (probably [heroicons](https://heroicons.com/))

--- a/app/models/kommandant/command.rb
+++ b/app/models/kommandant/command.rb
@@ -7,6 +7,10 @@ module Kommandant
         )
       end
 
+      def remove_from_index!
+        index.delete_all_documents!
+      end
+
       def search(query)
         result = index.search(query)["hits"]
 

--- a/lib/tasks/kommandant_tasks.rake
+++ b/lib/tasks/kommandant_tasks.rake
@@ -11,6 +11,21 @@ namespace :kommandant do
     Rake::Task["meilisearch:reindex"].invoke
   end
 
-  desc "Reindexes all commands and models. We recommend you run this task every time you deploy your application, to avoid any inconsistencies between what you expect to be indexed and what is actually indexed."
+  desc "Reindexes all commands and models. We recommend you run this task every time you deploy your application, to avoid any inconsistencies between what you expect to be indexed and what is actually indexed"
   task reindex: [:reindex_commands, :reindex_models]
+
+  desc "Clears the Kommandant commands from the search engine"
+  task clear_command_index: :environment do
+    puts "Clearing the Kommandant commands"
+
+    Kommandant::Command.remove_from_index!
+  end
+
+  desc "Clears the search engine of all models set up with Kommandant"
+  task clear_model_index: :environment do
+    Rake::Task["meilisearch:clear_indexes"].invoke
+  end
+
+  desc "Clears the search engine of all commands and models"
+  task clear_indexes: [:clear_command_index, :clear_model_index]
 end

--- a/lib/tasks/kommandant_tasks.rake
+++ b/lib/tasks/kommandant_tasks.rake
@@ -1,4 +1,16 @@
-# desc "Explaining what the task does"
-# task :kommandant do
-#   # Task goes here
-# end
+namespace :kommandant do
+  desc "Reindexes all commmands defined in the commands.json file (or whatever you called it)"
+  task reindex_commands: :environment do
+    puts "Reindexing all Kommandant commands"
+
+    Kommandant::Command.reindex!
+  end
+
+  desc "Reindexes all models set up with Kommandant"
+  task reindex_models: :environment do
+    Rake::Task["meilisearch:reindex"].invoke
+  end
+
+  desc "Reindexes all commands and models. We recommend you run this task every time you deploy your application, to avoid any inconsistencies between what you expect to be indexed and what is actually indexed."
+  task reindex: [:reindex_commands, :reindex_models]
+end

--- a/test/models/kommandant/command_test.rb
+++ b/test/models/kommandant/command_test.rb
@@ -14,6 +14,13 @@ module Kommandant
       assert_equal expected_result, MeiliSearch::Rails.client.index("commands").documents["results"]
     end
 
+    test ".remove_from_index! removes all commands from the search engine" do
+      Kommandant::Command.reindex!
+      Kommandant::Command.remove_from_index!
+
+      assert_empty MeiliSearch::Rails.client.index("commands").documents["results"]
+    end
+
     test ".search searches the commands in meilisearch by their translated name" do
       results = Kommandant::Command.search("End")
 


### PR DESCRIPTION
Adds the tasks below

```
rails kommandant:clear_command_index                 # Clears the Kommandant commands from the search engine
rails kommandant:clear_indexes                       # Clears the search engine of all commands and models
rails kommandant:clear_model_index                   # Clears the search engine of all models set up with Kommandant
rails kommandant:install:migrations                  # Copy migrations from kommandant to application
rails kommandant:reindex                             # Reindexes all commands and models
rails kommandant:reindex_commands                    # Reindexes all commmands defined in the commands.json file (or w...
rails kommandant:reindex_models                      # Reindexes all models set up with Kommandant
```